### PR TITLE
[setting] PR 오토 라벨링, PR 오토 담당자 설정함

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to 'author' to add PR's author as assignee
+addAssignees: author
+
+skipKeywords:
+  - wip

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,41 @@
+feat:
+  - head-branch: ['^feat', 'feat']
+
+setting:
+ - head-branch: ['^setting', 'setting']
+
+design:
+  - head-branch: ['^design', 'design']
+
+fix:
+  - head-branch: ['^fix', 'fix']
+
+chore:
+  - head-branch: ['^chore', 'chore']
+
+hotfix:
+  - head-branch: ['^hotfix', 'hotfix']
+
+style:
+  - head-branch: ['^style', 'style']
+
+refactor:
+  - head-branch: ['^refactor', 'refactor']
+
+test:
+  - head-branch: ['^test', 'test']
+
+docs:
+  - head-branch: ['^docs', 'docs']
+
+rename:
+  - head-branch: ['^rename', 'rename']
+
+remove:
+  - head-branch: ['^remove', 'remove']
+
+release:
+  - head-branch: ['^release', 'release']
+
+init:
+  - head-branch: ['^init', 'init']

--- a/.github/workflows/pr-auto_assign.yaml
+++ b/.github/workflows/pr-auto_assign.yaml
@@ -1,0 +1,8 @@
+name: 'Auto Assign'
+on: pull_request
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0

--- a/.github/workflows/pr-auto_assign.yaml
+++ b/.github/workflows/pr-auto_assign.yaml
@@ -1,5 +1,11 @@
 name: 'Auto Assign'
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   add-reviews:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

### PR 오토라벨링, PR오토담당자 설정하는 workflow를 세팅함.
- #5
- github action 파일 세팅
- `PR 오토 라벨링`은 PR 올린 헤드 브랜치명에 따라 결정됨. ex)
  feat/login-23 이면 feat이 자동으로 라벨링됨.
- `PR 오토 담당자 설정`은 PR을 작성한 사람이 자동으로 담당자가 되도록
  설정함

### 참고 자료
- https://github.com/marketplace/actions/auto-assign-action
- https://github.com/kentaro-m/auto-assign-action



## 🔧 Changes Summary

Summarize the key changes made.

## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

## 📄 Additional Information

If you have any additional information or special requests, please include them here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 자동 리뷰어 추가 및 할당 기능을 위한 GitHub 설정 파일 추가.
	- 풀 리퀘스트 기반의 라벨링 규칙 설정 파일 추가.
	- 자동 라벨링을 위한 GitHub Actions 워크플로우 추가.

- **개선 사항**
	- 풀 리퀘스트의 효율적인 관리 및 검토 프로세스를 위한 자동화 설정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->