### PR TITLE
[settings] github action을 이용해 자동으로 이슈 담당자를 설정하게함

### DIFF
--- a/.github/workflows/issue-auto_assign.yml
+++ b/.github/workflows/issue-auto_assign.yml
@@ -1,0 +1,14 @@
+name: Auto Assign Issue Creator
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assignAuthor:
+    name: Assign author to Issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Assign author to Issue
+        uses: technote-space/assign-author@v1


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

- **이슈를 작성하면 이슈 작성한 사람이 자동으로 이슈 담당자가 되도록 설정함.**

## 🔧 Changes Summary

Summarize the key changes made.

## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

## 📄 Additional Information

If you have any additional information or special requests, please include them here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 이슈 생성 시 자동으로 작성자를 해당 이슈의 담당자로 지정하는 워크플로우 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->